### PR TITLE
자동 PR: feature-sm-move-organization-test → dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     env:
       BRANCH_NAME: ${{ github.ref_name }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.MOYEORAIT_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div></div>;
+  return <div>test</div>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>test</div>;
+  return <div></div>;
 }


### PR DESCRIPTION
## Repository → Organization 이관

### 작업한 내용
- Repository에서 사용하던 토큰이 Organization에서는 사용 불가
- Fine-grained PAT 생성하여 적용
  ```
  // ci.yaml 
      env:
      GH_TOKEN: ${{ secrets.MOYEORAIT_TOKEN }}
  ```

### 참고 사항
- 사용된 Fine-grained PAT은 개인 Github 계정에서 생성한 토큰입니다.
- Organization token 접근 승인은 제가 했습니다.
- fail 됐던 이력은 token의 permission을 제대로 적용하지 않아 발생했던 오류입니다. → 권한 설정하여 재생성 후 적용했습니다.(정상작동)
- 추후 dev → main 머지 시 적용돼도 될 거 같아 main에 머지는 하지 않겠습니다.

---
### Commits
chore: CI에서 사용하던 repository token을 organization token으로 수정
chore: organization 이관 후 자동 pr 및 commit 정상 작동하는 지 확인